### PR TITLE
Add support for 'format' keyword

### DIFF
--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -147,6 +147,10 @@ module Dry
           visit_predicate(rest, opts)
         end
 
+        def visit_namespace(node, opts = {})
+          visit(node[1], opts)
+        end
+
         # @api private
         def visit_predicate(node, opts = EMPTY_HASH)
           name, rest = node

--- a/lib/dry/schema/extensions/json_schema/schema_compiler.rb
+++ b/lib/dry/schema/extensions/json_schema/schema_compiler.rb
@@ -31,6 +31,7 @@ module Dry
           included_in?: {enum: ->(v, _) { v.to_a }},
           filled?: EMPTY_HASH,
           uri?: {format: "uri"},
+          format?: {format: ->(v, _) { v }},
           uuid_v1?: {
             pattern: "^[0-9A-F]{8}-[0-9A-F]{4}-1[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$"
           },


### PR DESCRIPTION
Currently, running `schema.open_api` raises errors for Dry contracts with `format` specified:
```
class SomeContract < Dry::Validation::Contract
...
 optional(:weight).value(:string, format?: /\d+(\.\d+)?/)
...
end
```

Without this fix, the attribute `loose: true` needs to be called on `schema.open_api` method call.